### PR TITLE
refactor: split system prompt from user-editable review criteria

### DIFF
--- a/index.js
+++ b/index.js
@@ -525,7 +525,7 @@ async function callOpenClaw(userPrompt, context = '') {
   }
 
   // Combine user criteria with PR context
-  const userMessage = `## Review Criteria\n${userPrompt}\n\n## Pull Request Details\n${context}`;
+  const userMessage = `${userPrompt}\n\n## Pull Request Details\n${context}`;
 
   try {
     const response = await fetch(`${OPENCLAW_GATEWAY_URL}/v1/chat/completions`, {


### PR DESCRIPTION
## Summary
Separates the fixed system prompt (defines output format) from user-editable review criteria.

## Changes
- `SYSTEM_PROMPT` (hardcoded): Output format, verdict rules
- `DEFAULT_USER_PROMPT` (DB, overridable): Review criteria
- Renamed `global_prompt` → `user_prompt`

## Architecture
```
SYSTEM_PROMPT (fixed)
├── Output format: VERDICT: PASS/FAIL
├── Response structure
└── Basic rules

USER_PROMPT (customizable)
├── Review criteria
├── What to look for
└── Project-specific rules
```

## Why
- Prevents breaking verdict parsing when editing prompts
- Clear separation of concerns
- Easier customization without affecting mechanics