### PR TITLE
fix: deployments page shows only jean-ci (Coolify) deployments

### DIFF
--- a/app/admin/deployments/page.tsx
+++ b/app/admin/deployments/page.tsx
@@ -65,7 +65,7 @@ export default function DeploymentsPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-6">All Deployments ({data.total})</h1>
+      <h1 className="text-2xl font-bold mb-6">Coolify Deployments ({data.total})</h1>
       
       <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
         <table className="w-full">
@@ -73,7 +73,7 @@ export default function DeploymentsPage() {
             <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Time</th>
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Repository</th>
-              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Type</th>
+              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">App</th>
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Status</th>
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Details</th>
             </tr>
@@ -87,25 +87,14 @@ export default function DeploymentsPage() {
               data.items.map((d, idx) => {
                 const payload = typeof d.payload === 'string' ? JSON.parse(d.payload) : d.payload;
                 
-                let githubUrl: string | undefined;
-                let coolifyUrl: string | undefined;
+                // Get the actual repo (from _source_repo or repo field)
+                const actualRepo = payload?._source_repo || d.repo;
+                const appName = payload?._app_name || payload?.application_name || d.repo;
+                const coolifyUrl = payload?.deployment_url;
                 
-                if (payload?.workflow_run?.html_url) {
-                  githubUrl = payload.workflow_run.html_url;
-                } else if (payload?.workflow_run?.id && d.repo) {
-                  githubUrl = `https://github.com/${d.repo}/actions/runs/${payload.workflow_run.id}`;
-                }
-                
-                if (d.event_type?.startsWith('coolify_') && payload?.deployment_url) {
-                  coolifyUrl = payload.deployment_url;
-                }
-                
-                let status = d.action || payload?.workflow_run?.conclusion || payload?.deployment_status?.state || 'unknown';
-                if (d.event_type === 'coolify_deployment_success') status = 'success';
-                if (d.event_type === 'coolify_deployment_failed') status = 'failure';
-                
-                const workflowName = payload?.workflow_run?.name || payload?.workflow?.name || 
-                                    payload?.deployment?.environment || payload?.application_name || d.event_type;
+                // Determine status from event type
+                const isSuccess = d.event_type === 'coolify_deployment_success';
+                const isFailed = d.event_type === 'coolify_deployment_failed';
                 
                 return (
                   <tr key={d.id || idx} className="border-b border-[var(--border)] hover:bg-[var(--bg-card-hover)] transition-colors">
@@ -113,42 +102,36 @@ export default function DeploymentsPage() {
                       {d.created_at ? new Date(d.created_at).toLocaleString() : '-'}
                     </td>
                     <td className="py-3 px-4">
-                      {d.repo ? (
-                        <Link href={`/admin/repos/${d.repo}`} className="text-[var(--accent)] hover:underline">
-                          {d.repo}
+                      {actualRepo && actualRepo.includes('/') ? (
+                        <Link href={`/admin/repos/${actualRepo}`} className="text-[var(--accent)] hover:underline">
+                          {actualRepo}
                         </Link>
                       ) : (
-                        <span className="text-[var(--text-muted)]">-</span>
+                        <span className="text-[var(--text-muted)]">{actualRepo || '-'}</span>
                       )}
                     </td>
                     <td className="py-3 px-4">
-                      <span className="inline-block px-2 py-1 bg-[var(--bg-secondary)] border border-[var(--border)] rounded text-xs font-mono">
-                        {workflowName}
+                      <span className="inline-block px-2 py-1 bg-purple-500/10 text-purple-400 border border-purple-500/20 rounded text-xs font-mono">
+                        {appName}
                       </span>
                     </td>
                     <td className="py-3 px-4">
-                      {status === 'success' || status === 'completed' ? (
+                      {isSuccess ? (
                         <span className="text-[var(--green)]">✅ Success</span>
-                      ) : status === 'failure' || status === 'error' ? (
+                      ) : isFailed ? (
                         <span className="text-[var(--red)]">❌ Failed</span>
-                      ) : status === 'pending' || status === 'in_progress' || status === 'queued' || status === 'requested' || status === 'created' ? (
-                        <span className="text-yellow-600">⏳ {status}</span>
                       ) : (
-                        <span className="text-[var(--text-secondary)]">{status}</span>
+                        <span className="text-yellow-600">⏳ {d.action || 'pending'}</span>
                       )}
                     </td>
-                    <td className="py-3 px-4 flex gap-2">
-                      {githubUrl && (
-                        <a href={githubUrl} target="_blank" rel="noopener noreferrer" className="text-[var(--accent)] hover:underline">
-                          GitHub →
-                        </a>
-                      )}
-                      {coolifyUrl && (
+                    <td className="py-3 px-4">
+                      {coolifyUrl ? (
                         <a href={coolifyUrl} target="_blank" rel="noopener noreferrer" className="text-[var(--accent)] hover:underline">
                           Coolify →
                         </a>
+                      ) : (
+                        <span className="text-[var(--text-muted)]">-</span>
                       )}
-                      {!githubUrl && !coolifyUrl && <span className="text-[var(--text-muted)]">-</span>}
                     </td>
                   </tr>
                 );

--- a/app/api/webhook/coolify/route.ts
+++ b/app/api/webhook/coolify/route.ts
@@ -10,13 +10,22 @@ export async function POST(req: NextRequest) {
   
   const { event, message, application_uuid, deployment_url, application_name, deployment_uuid } = payload;
   
-  // Store Coolify event in database
+  // Get pending deployment info to find the actual repo
+  const pending = application_uuid ? pendingDeployments.get(application_uuid) : null;
+  const actualRepo = pending ? `${pending.owner}/${pending.repo}` : null;
+  
+  // Store Coolify event in database with the actual repo that triggered the deploy
   await insertEvent(
     `coolify_${event || 'unknown'}`,
     deployment_uuid || null,
-    application_name || null,
+    actualRepo || application_name || null,  // Prefer actual repo over app name
     event || null,
-    payload,
+    {
+      ...payload,
+      // Add actual repo info for display
+      _source_repo: actualRepo,
+      _app_name: application_name,
+    },
     'coolify'
   );
   
@@ -24,7 +33,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ received: true, ignored: 'no app uuid' });
   }
   
-  const pending = pendingDeployments.get(application_uuid);
   if (!pending) {
     console.log(`[Coolify] No pending deployment for ${application_uuid}`);
     return NextResponse.json({ received: true, ignored: 'no pending deployment' });

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -405,13 +405,11 @@ export async function getCheckRunsByRepoPaginated(repo: string, page = 1, limit 
 }
 
 export async function getDeploymentsByRepoCount(repo: string): Promise<number> {
+  // Only count Coolify deployments (jean-ci triggered)
   const result = await pool.query(
     `SELECT COUNT(*) FROM jean_ci_webhook_events 
      WHERE repo = $1 
-     AND (event_type = 'deployment_status' 
-          OR event_type = 'registry_package' 
-          OR event_type = 'workflow_run'
-          OR event_type LIKE 'coolify_%')`,
+     AND event_type LIKE 'coolify_%'`,
     [repo]
   );
   return parseInt(result.rows[0].count);
@@ -419,14 +417,12 @@ export async function getDeploymentsByRepoCount(repo: string): Promise<number> {
 
 export async function getDeploymentsByRepoPaginated(repo: string, page = 1, limit = 50): Promise<PaginatedResult<any>> {
   const offset = (page - 1) * limit;
+  // Only show Coolify deployments (jean-ci triggered)
   const [items, countResult] = await Promise.all([
     pool.query(
       `SELECT * FROM jean_ci_webhook_events 
        WHERE repo = $1 
-       AND (event_type = 'deployment_status' 
-            OR event_type = 'registry_package' 
-            OR event_type = 'workflow_run'
-            OR event_type LIKE 'coolify_%')
+       AND event_type LIKE 'coolify_%'
        ORDER BY created_at DESC
        LIMIT $2 OFFSET $3`,
       [repo, limit, offset]
@@ -434,10 +430,7 @@ export async function getDeploymentsByRepoPaginated(repo: string, page = 1, limi
     pool.query(
       `SELECT COUNT(*) FROM jean_ci_webhook_events 
        WHERE repo = $1 
-       AND (event_type = 'deployment_status' 
-            OR event_type = 'registry_package' 
-            OR event_type = 'workflow_run'
-            OR event_type LIKE 'coolify_%')`,
+       AND event_type LIKE 'coolify_%'`,
       [repo]
     )
   ]);
@@ -458,23 +451,18 @@ export async function getAllDeploymentsCount(): Promise<number> {
 
 export async function getAllDeploymentsPaginated(page = 1, limit = 50): Promise<PaginatedResult<any>> {
   const offset = (page - 1) * limit;
+  // Only show Coolify deployments (jean-ci triggered)
   const [items, countResult] = await Promise.all([
     pool.query(
       `SELECT * FROM jean_ci_webhook_events 
-       WHERE event_type = 'deployment_status' 
-          OR event_type = 'registry_package' 
-          OR event_type = 'workflow_run'
-          OR event_type LIKE 'coolify_%'
+       WHERE event_type LIKE 'coolify_%'
        ORDER BY created_at DESC
        LIMIT $1 OFFSET $2`,
       [limit, offset]
     ),
     pool.query(
       `SELECT COUNT(*) FROM jean_ci_webhook_events 
-       WHERE event_type = 'deployment_status' 
-          OR event_type = 'registry_package' 
-          OR event_type = 'workflow_run'
-          OR event_type LIKE 'coolify_%'`
+       WHERE event_type LIKE 'coolify_%'`
     )
   ]);
   const total = parseInt(countResult.rows[0].count);


### PR DESCRIPTION
<!-- oc-session:discord:1477178440686895206 -->

## Changes

- Filter deployments to only show `coolify_*` events (jean-ci triggered)
- Store actual source repo in Coolify webhook (not just app name)
- Update UI to show App column with Coolify app name
- Fix repository links to use actual triggering repo
- Rename page title to 'Coolify Deployments'

## Lesson learned
**ALWAYS check if PR is merged before pushing:** `gh pr view <number> --json state`