### PR TITLE
feat: show commit SHA in footer and health endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,10 @@ jobs:
       - name: Build and push Docker image
         run: |
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
-          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-                       -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-$SHORT_SHA .
+          docker build \
+            --build-arg COMMIT_SHA=$SHORT_SHA \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-$SHORT_SHA .
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-$SHORT_SHA
           echo "Pushed: sha-$SHORT_SHA"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /app
 # Install wget for healthcheck
 RUN apk add --no-cache wget
 
+# Build arg for commit SHA
+ARG COMMIT_SHA=unknown
+ENV NEXT_PUBLIC_COMMIT_SHA=$COMMIT_SHA
+
 # Copy package files
 COPY package*.json ./
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -4,6 +4,7 @@ export async function GET() {
   return NextResponse.json({ 
     status: 'ok', 
     app: 'jean-ci', 
-    version: '0.13.0' 
+    version: '0.13.0',
+    commit: process.env.NEXT_PUBLIC_COMMIT_SHA || 'unknown',
   });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,7 +58,13 @@ export default function HomePage() {
 
       {/* Footer */}
       <div className="py-8 px-4 text-center text-sm text-[var(--text-muted)] border-t border-[var(--border)] mt-16">
-        <p>jean-ci v0.13.0 · Part of the OpenClaw ecosystem</p>
+        <p>
+          jean-ci v0.13.0
+          {process.env.NEXT_PUBLIC_COMMIT_SHA && process.env.NEXT_PUBLIC_COMMIT_SHA !== 'unknown' && (
+            <span className="text-[var(--text-muted)]"> · {process.env.NEXT_PUBLIC_COMMIT_SHA}</span>
+          )}
+          <span className="text-[var(--text-muted)]"> · Part of the OpenClaw ecosystem</span>
+        </p>
       </div>
     </>
   );


### PR DESCRIPTION
<!-- oc-session:discord:1477178440686895206 -->

## Changes

Makes it easy to verify which commit is actually deployed:

- Footer: `jean-ci v0.13.0 · 8fd0400 · Part of the OpenClaw ecosystem`
- Health: `curl .../api/health` → `{..., "commit": "8fd0400"}`

### Implementation
- Dockerfile: `ARG COMMIT_SHA` → `ENV NEXT_PUBLIC_COMMIT_SHA`
- Workflow: `--build-arg COMMIT_SHA=$SHORT_SHA`
- Footer: conditionally renders SHA
- Health endpoint: includes commit field