### PR TITLE
fix: events page handles paginated API response

### DIFF
--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -9,26 +9,70 @@ interface Event {
   delivery_id?: string;
   repo?: string;
   action?: string;
+  source?: string;
   pr_number?: number;
   created_at: string;
 }
 
+interface PaginatedResult {
+  items: Event[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+function Pagination({ page, totalPages, onPageChange }: { page: number; totalPages: number; onPageChange: (p: number) => void }) {
+  if (totalPages <= 1) return null;
+  return (
+    <div className="flex items-center justify-center gap-2 mt-4">
+      <button
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        className="px-3 py-1 rounded bg-[var(--bg-secondary)] border border-[var(--border)] disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[var(--bg-card-hover)]"
+      >
+        ← Prev
+      </button>
+      <span className="text-sm text-[var(--text-secondary)]">
+        Page {page} of {totalPages}
+      </span>
+      <button
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        className="px-3 py-1 rounded bg-[var(--bg-secondary)] border border-[var(--border)] disabled:opacity-50 disabled:cursor-not-allowed hover:bg-[var(--bg-card-hover)]"
+      >
+        Next →
+      </button>
+    </div>
+  );
+}
+
 export default function EventsPage() {
-  const [events, setEvents] = useState<Event[]>([]);
+  const [data, setData] = useState<PaginatedResult>({ items: [], total: 0, page: 1, limit: 50, totalPages: 0 });
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<string>('');
 
+  const fetchPage = async (page: number) => {
+    const result = await fetch(`/api/events?page=${page}`).then(r => r.json());
+    // Handle both old array format and new paginated format
+    if (Array.isArray(result)) {
+      setData({ items: result, total: result.length, page: 1, limit: result.length, totalPages: 1 });
+    } else if (result.items) {
+      setData(result);
+    } else {
+      setData({ items: [], total: 0, page: 1, limit: 50, totalPages: 0 });
+    }
+  };
+
   useEffect(() => {
-    fetch('/api/events').then(r => r.json()).then(data => {
-      setEvents(data);
-      setLoading(false);
-    });
+    fetchPage(1).then(() => setLoading(false));
   }, []);
 
   if (loading) {
     return <div className="text-center py-12 text-[var(--text-muted)]">Loading...</div>;
   }
 
+  const events = data.items;
   const eventTypes = [...new Set(events.map(e => e.event_type))];
   const filteredEvents = filter ? events.filter(e => e.event_type === filter) : events;
 
@@ -36,9 +80,9 @@ export default function EventsPage() {
     <div>
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
         <div>
-          <h1 className="text-2xl font-bold">Events</h1>
+          <h1 className="text-2xl font-bold">Events ({data.total})</h1>
           <p className="text-[var(--text-secondary)] mt-1">
-            Recent webhook events from GitHub
+            Recent webhook events from GitHub and Coolify
           </p>
         </div>
       </div>
@@ -71,7 +115,7 @@ export default function EventsPage() {
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Event</th>
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Repository</th>
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Action</th>
-              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Details</th>
+              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Source</th>
             </tr>
           </thead>
           <tbody className="text-sm">
@@ -89,24 +133,21 @@ export default function EventsPage() {
                     </span>
                   </td>
                   <td className="py-3 px-4">
-                    {e.repo ? (
+                    {e.repo && e.repo.includes('/') ? (
                       <Link href={`/admin/repos/${e.repo}`} className="text-[var(--accent)] hover:underline">
                         {e.repo}
                       </Link>
-                    ) : '-'}
+                    ) : (
+                      <span className="text-[var(--text-muted)]">{e.repo || '-'}</span>
+                    )}
                   </td>
                   <td className="py-3 px-4 text-[var(--text-secondary)]">{e.action || '-'}</td>
-                  <td className="py-3 px-4 text-[var(--text-secondary)]">
-                    {e.pr_number && e.repo && (
-                      <a 
-                        href={`https://github.com/${e.repo}/pull/${e.pr_number}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-[var(--accent)] hover:underline"
-                      >
-                        PR #{e.pr_number}
-                      </a>
-                    )}
+                  <td className="py-3 px-4">
+                    <span className={`inline-block px-2 py-0.5 rounded text-xs ${
+                      e.source === 'coolify' ? 'bg-purple-500/10 text-purple-400' : 'bg-blue-500/10 text-blue-400'
+                    }`}>
+                      {e.source || 'github'}
+                    </span>
                   </td>
                 </tr>
               ))
@@ -114,6 +155,7 @@ export default function EventsPage() {
           </tbody>
         </table>
       </div>
+      <Pagination page={data.page} totalPages={data.totalPages} onPageChange={fetchPage} />
     </div>
   );
 }


### PR DESCRIPTION
<!-- oc-session:discord:1477178440686895206 -->

## Changes

Fix `TypeError: e.map is not a function` on /admin/events page.

The events API now returns `{items, total, page, ...}` but the page expected an array.

- Update to use PaginatedResult format
- Add pagination controls  
- Show total count in header
- Add source column (github/coolify)
- Handle both formats for compatibility