### PR TITLE
fix: exclude test workflows from pipeline view

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -551,6 +551,7 @@ export async function getDeploymentPipelines(page = 1, limit = 20): Promise<Pagi
            OR LOWER(payload->'workflow_run'->>'name') LIKE '%deploy%'
            OR LOWER(payload->'workflow_run'->>'name') LIKE '%release%'
          )
+         AND LOWER(payload->'workflow_run'->>'name') NOT LIKE '%test%'
        )
      )
      ORDER BY created_at DESC
@@ -715,6 +716,7 @@ export async function getDeploymentPipelinesByRepo(repo: string, page = 1, limit
            OR LOWER(payload->'workflow_run'->>'name') LIKE '%deploy%'
            OR LOWER(payload->'workflow_run'->>'name') LIKE '%release%'
          )
+         AND LOWER(payload->'workflow_run'->>'name') NOT LIKE '%test%'
        )
      )
      ORDER BY created_at DESC


### PR DESCRIPTION
<!-- oc-session:discord:1477178440686895206 -->

Excludes workflows containing 'test' from pipeline view.

Fixes: `test_build` workflows being shown because they contain 'build'.

```sql
AND LOWER(payload->'workflow_run'->>'name') NOT LIKE '%test%'
```