### PR TITLE
feat: add open PRs list to reviews page

### DIFF
--- a/app/admin/reviews/page.tsx
+++ b/app/admin/reviews/page.tsx
@@ -16,8 +16,19 @@ interface CheckRun {
   completed_at?: string;
 }
 
-interface PaginatedResult {
-  items: CheckRun[];
+interface OpenPR {
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  headSha: string;
+  url: string;
+  checkStatus: 'pending' | 'success' | 'failure';
+  updatedAt: string;
+}
+
+interface PaginatedResult<T> {
+  items: T[];
   total: number;
   page: number;
   limit: number;
@@ -49,18 +60,43 @@ function Pagination({ page, totalPages, onPageChange }: { page: number; totalPag
   );
 }
 
+function formatRelativeTime(timestamp: string): string {
+  const now = Date.now();
+  const then = new Date(timestamp).getTime();
+  const diff = now - then;
+  
+  if (diff < 60000) return 'just now';
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  return `${Math.floor(diff / 86400000)}d ago`;
+}
+
 export default function ReviewsPage() {
-  const [data, setData] = useState<PaginatedResult>({ items: [], total: 0, page: 1, limit: 50, totalPages: 0 });
+  const [prs, setPRs] = useState<PaginatedResult<OpenPR>>({ items: [], total: 0, page: 1, limit: 20, totalPages: 0 });
+  const [reviews, setReviews] = useState<PaginatedResult<CheckRun>>({ items: [], total: 0, page: 1, limit: 50, totalPages: 0 });
   const [loading, setLoading] = useState(true);
 
-  const fetchPage = async (page: number) => {
+  const fetchPRs = async (page: number) => {
+    const result = await fetch(`/api/prs?page=${page}`).then(r => r.json());
+    setPRs(result.items ? result : { items: [], total: 0, page: 1, limit: 20, totalPages: 0 });
+  };
+
+  const fetchReviews = async (page: number) => {
     const result = await fetch(`/api/checks?page=${page}`).then(r => r.json());
-    setData(result.items ? result : { items: [], total: 0, page: 1, limit: 50, totalPages: 0 });
+    setReviews(result.items ? result : { items: [], total: 0, page: 1, limit: 50, totalPages: 0 });
   };
 
   useEffect(() => {
-    fetchPage(1).then(() => setLoading(false));
+    Promise.all([fetchPRs(1), fetchReviews(1)]).then(() => setLoading(false));
   }, []);
+
+  const getCheckStatusIcon = (status: 'pending' | 'success' | 'failure') => {
+    switch (status) {
+      case 'success': return <span className="text-[var(--green)]">✅</span>;
+      case 'failure': return <span className="text-[var(--red)]">❌</span>;
+      case 'pending': return <span className="text-yellow-500">⌛</span>;
+    }
+  };
 
   const getStatusBadge = (status: string, conclusion?: string) => {
     if (status === 'completed') {
@@ -82,74 +118,146 @@ export default function ReviewsPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-6">All PR Reviews ({data.total})</h1>
-      
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-        <table className="w-full">
-          <thead>
-            <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
-              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Time</th>
-              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Repository</th>
-              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">PR</th>
-              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Status</th>
-              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Title</th>
-              <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Details</th>
-            </tr>
-          </thead>
-          <tbody className="text-sm">
-            {data.items.length === 0 ? (
-              <tr>
-                <td colSpan={6} className="py-8 text-center text-[var(--text-muted)]">No PR reviews yet.</td>
+      {/* Open PRs Section */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold mb-4">Open Pull Requests ({prs.total})</h1>
+        <p className="text-[var(--text-secondary)] mb-4">PRs in repositories with code review enabled</p>
+        
+        <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
+                <th className="text-center py-3 px-4 text-sm font-semibold text-[var(--text-secondary)] w-16">Status</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Repository</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">PR</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Title</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Author</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Updated</th>
               </tr>
-            ) : (
-              data.items.map(c => (
-                <tr key={c.id} className="border-b border-[var(--border)] hover:bg-[var(--bg-card-hover)] transition-colors">
-                  <td className="py-3 px-4 text-[var(--text-muted)] whitespace-nowrap">
-                    {new Date(c.created_at).toLocaleString()}
-                  </td>
-                  <td className="py-3 px-4">
-                    <Link href={`/admin/repos/${c.repo}`} className="text-[var(--accent)] hover:underline">
-                      {c.repo}
-                    </Link>
-                  </td>
-                  <td className="py-3 px-4">
-                    <a 
-                      href={`https://github.com/${c.repo}/pull/${c.pr_number}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-[var(--accent)] hover:underline font-medium"
-                    >
-                      #{c.pr_number}
-                    </a>
-                  </td>
-                  <td className="py-3 px-4">
-                    {getStatusBadge(c.status, c.conclusion)}
-                  </td>
-                  <td className="py-3 px-4 text-[var(--text-secondary)] max-w-xs truncate">
-                    {c.title || '-'}
-                  </td>
-                  <td className="py-3 px-4">
-                    <Link href={`/checks/${c.id}`} className="text-[var(--accent)] hover:underline">
-                      View Details →
-                    </Link>
-                    {c.github_check_id && (
+            </thead>
+            <tbody className="text-sm">
+              {prs.items.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-[var(--text-muted)]">No open PRs found.</td>
+                </tr>
+              ) : (
+                prs.items.map(pr => (
+                  <tr key={`${pr.repo}-${pr.number}`} className="border-b border-[var(--border)] hover:bg-[var(--bg-card-hover)] transition-colors">
+                    <td className="py-3 px-4 text-center text-lg">
+                      {getCheckStatusIcon(pr.checkStatus)}
+                    </td>
+                    <td className="py-3 px-4">
+                      <Link href={`/admin/repos/${pr.repo}`} className="text-[var(--accent)] hover:underline">
+                        {pr.repo}
+                      </Link>
+                    </td>
+                    <td className="py-3 px-4">
                       <a 
-                        href={`https://github.com/${c.repo}/runs/${c.github_check_id}`}
+                        href={pr.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="ml-2 text-xs text-[var(--text-muted)] hover:text-[var(--accent)]"
+                        className="text-[var(--accent)] hover:underline font-medium"
                       >
-                        (GitHub)
+                        #{pr.number}
                       </a>
-                    )}
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+                      <span className="ml-2 text-xs text-[var(--text-muted)] font-mono">{pr.headSha}</span>
+                    </td>
+                    <td className="py-3 px-4 text-[var(--text-secondary)] max-w-xs truncate" title={pr.title}>
+                      {pr.title}
+                    </td>
+                    <td className="py-3 px-4 text-[var(--text-muted)]">
+                      {pr.author}
+                    </td>
+                    <td className="py-3 px-4 text-[var(--text-muted)] whitespace-nowrap">
+                      {formatRelativeTime(pr.updatedAt)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+        <Pagination page={prs.page} totalPages={prs.totalPages} onPageChange={fetchPRs} />
+        
+        <div className="mt-3 text-sm text-[var(--text-muted)] flex items-center gap-4">
+          <span>Legend:</span>
+          <span className="flex items-center gap-1"><span className="text-[var(--green)]">✅</span> Ready to merge</span>
+          <span className="flex items-center gap-1"><span className="text-[var(--red)]">❌</span> Failed checks</span>
+          <span className="flex items-center gap-1"><span className="text-yellow-500">⌛</span> Pending checks</span>
+        </div>
       </div>
-      <Pagination page={data.page} totalPages={data.totalPages} onPageChange={fetchPage} />
+
+      {/* Reviews History Section */}
+      <div>
+        <h2 className="text-xl font-bold mb-4">Review History ({reviews.total})</h2>
+        
+        <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Time</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Repository</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">PR</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Status</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Title</th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Details</th>
+              </tr>
+            </thead>
+            <tbody className="text-sm">
+              {reviews.items.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-[var(--text-muted)]">No PR reviews yet.</td>
+                </tr>
+              ) : (
+                reviews.items.map(c => (
+                  <tr key={c.id} className="border-b border-[var(--border)] hover:bg-[var(--bg-card-hover)] transition-colors">
+                    <td className="py-3 px-4 text-[var(--text-muted)] whitespace-nowrap">
+                      {new Date(c.created_at).toLocaleString()}
+                    </td>
+                    <td className="py-3 px-4">
+                      <Link href={`/admin/repos/${c.repo}`} className="text-[var(--accent)] hover:underline">
+                        {c.repo}
+                      </Link>
+                    </td>
+                    <td className="py-3 px-4">
+                      <a 
+                        href={`https://github.com/${c.repo}/pull/${c.pr_number}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[var(--accent)] hover:underline font-medium"
+                      >
+                        #{c.pr_number}
+                      </a>
+                    </td>
+                    <td className="py-3 px-4">
+                      {getStatusBadge(c.status, c.conclusion)}
+                    </td>
+                    <td className="py-3 px-4 text-[var(--text-secondary)] max-w-xs truncate">
+                      {c.title || '-'}
+                    </td>
+                    <td className="py-3 px-4">
+                      <Link href={`/checks/${c.id}`} className="text-[var(--accent)] hover:underline">
+                        View Details →
+                      </Link>
+                      {c.github_check_id && (
+                        <a 
+                          href={`https://github.com/${c.repo}/runs/${c.github_check_id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="ml-2 text-xs text-[var(--text-muted)] hover:text-[var(--accent)]"
+                        >
+                          (GitHub)
+                        </a>
+                      )}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+        <Pagination page={reviews.page} totalPages={reviews.totalPages} onPageChange={fetchReviews} />
+      </div>
     </div>
   );
 }

--- a/app/api/prs/route.ts
+++ b/app/api/prs/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import { getReposWithPRReviewEnabled, getLatestCheckForPR, OpenPR } from '@/lib/db';
+import { getInstallationOctokit } from '@/lib/github';
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth();
+  if (!auth.authorized) {
+    return NextResponse.json({ error: auth.error }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const page = parseInt(url.searchParams.get('page') || '1');
+  const limit = Math.min(parseInt(url.searchParams.get('limit') || '20'), 50);
+
+  try {
+    // Get all repos with PR review enabled
+    const repos = await getReposWithPRReviewEnabled();
+    
+    // Fetch open PRs from each repo
+    const allPRs: OpenPR[] = [];
+    
+    for (const repo of repos) {
+      try {
+        const octokit = await getInstallationOctokit(repo.installation_id);
+        const [owner, repoName] = repo.full_name.split('/');
+        
+        const { data: prs } = await octokit.pulls.list({
+          owner,
+          repo: repoName,
+          state: 'open',
+          sort: 'updated',
+          direction: 'desc',
+          per_page: 30,
+        });
+        
+        for (const pr of prs) {
+          // Get our latest check status from DB
+          const check = await getLatestCheckForPR(repo.full_name, pr.number);
+          
+          let checkStatus: 'pending' | 'success' | 'failure' = 'pending';
+          if (check) {
+            if (check.status === 'completed') {
+              checkStatus = check.conclusion === 'success' ? 'success' : 'failure';
+            } else {
+              checkStatus = 'pending';
+            }
+          }
+          
+          allPRs.push({
+            repo: repo.full_name,
+            number: pr.number,
+            title: pr.title,
+            author: pr.user?.login || 'unknown',
+            headSha: pr.head.sha.substring(0, 7),
+            url: pr.html_url,
+            checkStatus,
+            updatedAt: pr.updated_at,
+          });
+        }
+      } catch (error) {
+        console.error(`Failed to fetch PRs for ${repo.full_name}:`, error);
+      }
+    }
+    
+    // Sort by updated date
+    allPRs.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    
+    // Paginate
+    const total = allPRs.length;
+    const totalPages = Math.ceil(total / limit);
+    const offset = (page - 1) * limit;
+    const items = allPRs.slice(offset, offset + limit);
+    
+    return NextResponse.json({ items, total, page, limit, totalPages });
+  } catch (error) {
+    console.error('Failed to fetch PRs:', error);
+    return NextResponse.json({ error: 'Failed to fetch PRs' }, { status: 500 });
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -945,3 +945,31 @@ export function buildCoolifyDeploymentUrl(appUuid: string, deploymentUuid: strin
   const coolifyUrl = process.env.COOLIFY_DASHBOARD_URL || 'https://apps.telegraphic.app';
   return `${coolifyUrl}/deployments/${deploymentUuid}`;
 }
+
+export async function getReposWithPRReviewEnabled(): Promise<{ full_name: string; installation_id: number }[]> {
+  const result = await pool.query(
+    `SELECT full_name, installation_id FROM jean_ci_repos WHERE pr_review_enabled = TRUE ORDER BY full_name`
+  );
+  return result.rows;
+}
+
+export interface OpenPR {
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  headSha: string;
+  url: string;
+  checkStatus: 'pending' | 'success' | 'failure';
+  updatedAt: string;
+}
+
+export async function getLatestCheckForPR(repo: string, prNumber: number): Promise<{ status: string; conclusion?: string } | null> {
+  const result = await pool.query(
+    `SELECT status, conclusion FROM jean_ci_check_runs 
+     WHERE repo = $1 AND pr_number = $2 
+     ORDER BY created_at DESC LIMIT 1`,
+    [repo, prNumber]
+  );
+  return result.rows[0] || null;
+}


### PR DESCRIPTION
<!-- oc-session:discord:1477178440686895206 -->

## Changes

Add a list of open PRs to the  page with their check status.

### Features
- **Open PRs table** at the top showing all PRs in repos with PR review enabled
- **Status icons**: ✅ for ready to merge, ❌ for failed checks, ⌛ for pending
- **Reviews history** moved below the PRs table
- Both tables are paginated
- Shows repo, PR number, title, author, and last updated time

### Implementation
- New `/api/prs` endpoint fetches open PRs from GitHub
- `getReposWithPRReviewEnabled()` gets repos with PR reviews enabled
- `getLatestCheckForPR()` gets our latest check status for each PR
- Matches GitHub PRs with our check runs to determine status