### PR TITLE
refactor: use stored events instead of GitHub API for open PRs

### DIFF
--- a/app/api/prs/route.ts
+++ b/app/api/prs/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { getReposWithPRReviewEnabled, getLatestCheckForPR, OpenPR } from '@/lib/db';
-import { getInstallationOctokit } from '@/lib/github';
+import { getOpenPRsFromEvents } from '@/lib/db';
 
 export async function GET(req: NextRequest) {
   const auth = await requireAuth();
@@ -14,57 +13,8 @@ export async function GET(req: NextRequest) {
   const limit = Math.min(parseInt(url.searchParams.get('limit') || '20'), 50);
 
   try {
-    // Get all repos with PR review enabled
-    const repos = await getReposWithPRReviewEnabled();
-    
-    // Fetch open PRs from each repo
-    const allPRs: OpenPR[] = [];
-    
-    for (const repo of repos) {
-      try {
-        const octokit = await getInstallationOctokit(repo.installation_id);
-        const [owner, repoName] = repo.full_name.split('/');
-        
-        const { data: prs } = await octokit.request('GET /repos/{owner}/{repo}/pulls', {
-          owner,
-          repo: repoName,
-          state: 'open',
-          sort: 'updated',
-          direction: 'desc',
-          per_page: 30,
-        });
-        
-        for (const pr of prs) {
-          // Get our latest check status from DB
-          const check = await getLatestCheckForPR(repo.full_name, pr.number);
-          
-          let checkStatus: 'pending' | 'success' | 'failure' = 'pending';
-          if (check) {
-            if (check.status === 'completed') {
-              checkStatus = check.conclusion === 'success' ? 'success' : 'failure';
-            } else {
-              checkStatus = 'pending';
-            }
-          }
-          
-          allPRs.push({
-            repo: repo.full_name,
-            number: pr.number,
-            title: pr.title,
-            author: pr.user?.login || 'unknown',
-            headSha: pr.head.sha.substring(0, 7),
-            url: pr.html_url,
-            checkStatus,
-            updatedAt: pr.updated_at,
-          });
-        }
-      } catch (error) {
-        console.error(`Failed to fetch PRs for ${repo.full_name}:`, error);
-      }
-    }
-    
-    // Sort by updated date
-    allPRs.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    // Get open PRs from stored webhook events (no GitHub API calls)
+    const allPRs = await getOpenPRsFromEvents();
     
     // Paginate
     const total = allPRs.length;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -973,3 +973,53 @@ export async function getLatestCheckForPR(repo: string, prNumber: number): Promi
   );
   return result.rows[0] || null;
 }
+
+export async function getOpenPRsFromEvents(): Promise<OpenPR[]> {
+  // Get latest PR events per repo/pr_number, excluding closed PRs
+  const result = await pool.query(`
+    WITH latest_pr_events AS (
+      SELECT DISTINCT ON (repo, (payload->>'number')::int)
+        repo,
+        (payload->>'number')::int as pr_number,
+        payload,
+        created_at
+      FROM jean_ci_webhook_events
+      WHERE event_type = 'pull_request'
+        AND repo IN (SELECT full_name FROM jean_ci_repos WHERE pr_review_enabled = TRUE)
+      ORDER BY repo, (payload->>'number')::int, created_at DESC
+    )
+    SELECT * FROM latest_pr_events
+    WHERE payload->>'action' != 'closed'
+    ORDER BY created_at DESC
+  `);
+
+  const prs: OpenPR[] = [];
+  
+  for (const row of result.rows) {
+    const payload = typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload;
+    const pr = payload.pull_request || payload;
+    
+    // Get latest check status for this PR
+    const check = await getLatestCheckForPR(row.repo, row.pr_number);
+    
+    let checkStatus: 'pending' | 'success' | 'failure' = 'pending';
+    if (check) {
+      if (check.status === 'completed') {
+        checkStatus = check.conclusion === 'success' ? 'success' : 'failure';
+      }
+    }
+    
+    prs.push({
+      repo: row.repo,
+      number: row.pr_number,
+      title: pr.title || `PR #${row.pr_number}`,
+      author: pr.user?.login || payload.sender?.login || 'unknown',
+      headSha: (pr.head?.sha || '').substring(0, 7),
+      url: pr.html_url || `https://github.com/${row.repo}/pull/${row.pr_number}`,
+      checkStatus,
+      updatedAt: pr.updated_at || row.created_at,
+    });
+  }
+  
+  return prs;
+}


### PR DESCRIPTION
<!-- oc-session:discord:1477178440686895206 -->

## Changes

Use our stored webhook events instead of calling GitHub API to list open PRs.

### Before
- Called GitHub API for each repo with PR reviews enabled
- Potential rate limiting issues
- Slower (network calls)

### After
- Query `jean_ci_webhook_events` table directly
- Get latest PR event per repo/number
- Filter out closed PRs
- Join with check_runs for status
- Much faster, no external API calls