### PR TITLE
feat: include 'publish' workflows in pipeline filter

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -577,6 +577,7 @@ export async function getDeploymentPipelines(page = 1, limit = 20): Promise<Pagi
            LOWER(payload->'workflow_run'->>'name') LIKE '%build%'
            OR LOWER(payload->'workflow_run'->>'name') LIKE '%deploy%'
            OR LOWER(payload->'workflow_run'->>'name') LIKE '%release%'
+           OR LOWER(payload->'workflow_run'->>'name') LIKE '%publish%'
          )
          AND LOWER(payload->'workflow_run'->>'name') NOT LIKE '%test%'
        )
@@ -758,6 +759,7 @@ export async function getDeploymentPipelinesByRepo(repo: string, page = 1, limit
            LOWER(payload->'workflow_run'->>'name') LIKE '%build%'
            OR LOWER(payload->'workflow_run'->>'name') LIKE '%deploy%'
            OR LOWER(payload->'workflow_run'->>'name') LIKE '%release%'
+           OR LOWER(payload->'workflow_run'->>'name') LIKE '%publish%'
          )
          AND LOWER(payload->'workflow_run'->>'name') NOT LIKE '%test%'
        )


### PR DESCRIPTION
Adds 'publish' to the workflow name filter for pipeline views.

Previously only workflows containing 'build', 'deploy', or 'release' were shown. This caused 'Publish to GHCR' workflows to be filtered out.

**Changes:**
- Updated `getDeploymentPipelines()` filter
- Updated `getRepoPipelines()` filter

Closes the gap where repos using 'Publish' naming convention don't show Build status in pipelines.