### PR TITLE
feat: add open PRs and pending deploys to dashboard

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -7,6 +7,8 @@ interface Stats {
   totalRepos: number;
   enabledRepos: number;
   recentEvents: number;
+  openPRs: number;
+  pendingDeploys: number;
 }
 
 export default function AdminOverview() {
@@ -16,11 +18,14 @@ export default function AdminOverview() {
     Promise.all([
       fetch('/api/repos').then(r => r.json()),
       fetch('/api/events').then(r => r.json()),
-    ]).then(([repos, events]) => {
+      fetch('/api/stats').then(r => r.json()),
+    ]).then(([repos, events, dashStats]) => {
       setStats({
         totalRepos: repos.length,
         enabledRepos: repos.filter((r: any) => r.pr_review_enabled).length,
         recentEvents: events.length,
+        openPRs: dashStats.openPRs,
+        pendingDeploys: dashStats.pendingDeploys,
       });
     });
   }, []);
@@ -29,23 +34,35 @@ export default function AdminOverview() {
     <div>
       <h1 className="text-2xl font-bold mb-6">Dashboard</h1>
       
-      <div className="grid md:grid-cols-3 gap-4 mb-8">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-8">
+        <Link href="/admin/reviews" className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl p-6 hover:shadow-lg transition-shadow">
+          <div className="text-3xl mb-2">🔀</div>
+          <div className="text-3xl font-bold text-[var(--blue)]">{stats?.openPRs ?? '...'}</div>
+          <div className="text-sm text-[var(--text-secondary)]">Open PRs</div>
+        </Link>
+        
+        <Link href="/admin/deployments" className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl p-6 hover:shadow-lg transition-shadow">
+          <div className="text-3xl mb-2">🚀</div>
+          <div className="text-3xl font-bold text-[var(--yellow)]">{stats?.pendingDeploys ?? '...'}</div>
+          <div className="text-sm text-[var(--text-secondary)]">Pending Deploys</div>
+        </Link>
+        
         <Link href="/admin/repos" className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl p-6 hover:shadow-lg transition-shadow">
           <div className="text-3xl mb-2">📦</div>
           <div className="text-3xl font-bold">{stats?.totalRepos ?? '...'}</div>
-          <div className="text-sm text-[var(--text-secondary)]">Total Repositories</div>
+          <div className="text-sm text-[var(--text-secondary)]">Repositories</div>
         </Link>
         
         <Link href="/admin/repos?filter=enabled" className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl p-6 hover:shadow-lg transition-shadow">
           <div className="text-3xl mb-2">✅</div>
           <div className="text-3xl font-bold text-[var(--green)]">{stats?.enabledRepos ?? '...'}</div>
-          <div className="text-sm text-[var(--text-secondary)]">PR Reviews Enabled</div>
+          <div className="text-sm text-[var(--text-secondary)]">Reviews Enabled</div>
         </Link>
         
         <Link href="/admin/events" className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl p-6 hover:shadow-lg transition-shadow">
           <div className="text-3xl mb-2">📋</div>
           <div className="text-3xl font-bold">{stats?.recentEvents ?? '...'}</div>
-          <div className="text-sm text-[var(--text-secondary)]">Recent Events</div>
+          <div className="text-sm text-[var(--text-secondary)]">Events</div>
         </Link>
       </div>
 

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { getOpenPRsCount, getPendingDeploymentsCount } from '@/lib/db';
+
+export async function GET() {
+  const [openPRs, pendingDeploys] = await Promise.all([
+    getOpenPRsCount(),
+    getPendingDeploymentsCount(),
+  ]);
+
+  return NextResponse.json({
+    openPRs,
+    pendingDeploys,
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,6 +18,7 @@
   --red: #b8473a;
   --yellow: #9a6f00;
   --purple: #7350ba;
+  --blue: #2563eb;
 }
 
 body {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1081,3 +1081,27 @@ export async function getEventById(id: number): Promise<{ event: any; payload: a
     payload: maskSensitiveData(payload),
   };
 }
+
+// Dashboard stats
+export async function getOpenPRsCount(): Promise<number> {
+  const result = await pool.query(`
+    WITH latest_pr_events AS (
+      SELECT DISTINCT ON (repo, (payload->>'number')::int)
+        repo,
+        (payload->>'number')::int as pr_number,
+        payload->'pull_request'->>'state' as state
+      FROM jean_ci_webhook_events
+      WHERE event_type = 'pull_request'
+      ORDER BY repo, (payload->>'number')::int, created_at DESC
+    )
+    SELECT COUNT(*) as count FROM latest_pr_events WHERE state = 'open'
+  `);
+  return parseInt(result.rows[0]?.count || '0', 10);
+}
+
+export async function getPendingDeploymentsCount(): Promise<number> {
+  const result = await pool.query(
+    'SELECT COUNT(*) as count FROM jean_ci_pending_deployments'
+  );
+  return parseInt(result.rows[0]?.count || '0', 10);
+}


### PR DESCRIPTION
Adds more useful metrics to the dashboard:

**New stats:**
- 🔀 Open PRs - links to /admin/reviews
- 🚀 Pending Deploys - links to /admin/deployments

**Changes:**
- Added `getOpenPRsCount()` and `getPendingDeploymentsCount()` to db.ts
- Created `/api/stats` endpoint
- Updated dashboard to show 5 stat cards in a responsive grid
- Added `--blue` CSS variable