### PR TITLE
fix: enable horizontal scroll for tables on mobile

### DIFF
--- a/app/admin/deployments/page.tsx
+++ b/app/admin/deployments/page.tsx
@@ -140,8 +140,8 @@ export default function DeploymentsPage() {
         </div>
       </div>
 
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-        <table className="w-full">
+      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-x-auto">
+        <table className="w-full min-w-[700px]">
           <thead>
             <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Commit</th>

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -197,8 +197,8 @@ export default function EventsPage() {
       </div>
 
       {/* Events table */}
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-        <table className="w-full">
+      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-x-auto">
+        <table className="w-full min-w-[800px]">
           <thead>
             <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Time</th>

--- a/app/admin/repos/[owner]/[repo]/page.tsx
+++ b/app/admin/repos/[owner]/[repo]/page.tsx
@@ -266,8 +266,8 @@ export default function RepoDetailPage() {
       {/* PR Reviews Tab */}
       {activeTab === 'checks' && (
         <div>
-          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-            <table className="w-full">
+          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-x-auto">
+            <table className="w-full min-w-[700px]">
               <thead>
                 <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
                   <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">PR</th>
@@ -332,8 +332,8 @@ export default function RepoDetailPage() {
       {/* Deployments Tab - Pipeline View */}
       {activeTab === 'deployments' && (
         <div>
-          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-            <table className="w-full">
+          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-x-auto">
+            <table className="w-full min-w-[600px]">
               <thead>
                 <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
                   <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Commit</th>
@@ -397,8 +397,8 @@ export default function RepoDetailPage() {
       {/* Events Tab */}
       {activeTab === 'events' && (
         <div>
-          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-            <table className="w-full">
+          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-x-auto">
+            <table className="w-full min-w-[500px]">
               <thead>
                 <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
                   <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Event</th>

--- a/app/admin/repos/page.tsx
+++ b/app/admin/repos/page.tsx
@@ -149,8 +149,8 @@ export default function ReposPage() {
       </div>
 
       {/* Repos table */}
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-        <table className="w-full">
+      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-x-auto">
+        <table className="w-full min-w-[600px]">
           <thead>
             <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
               <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Repository</th>

--- a/app/admin/reviews/page.tsx
+++ b/app/admin/reviews/page.tsx
@@ -123,8 +123,8 @@ export default function ReviewsPage() {
         <h1 className="text-2xl font-bold mb-4">Open Pull Requests ({prs.total})</h1>
         <p className="text-[var(--text-secondary)] mb-4">PRs in repositories with code review enabled</p>
         
-        <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-          <table className="w-full">
+        <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-x-auto">
+          <table className="w-full min-w-[800px]">
             <thead>
               <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
                 <th className="text-center py-3 px-4 text-sm font-semibold text-[var(--text-secondary)] w-16">Status</th>
@@ -191,8 +191,8 @@ export default function ReviewsPage() {
       <div>
         <h2 className="text-xl font-bold mb-4">Review History ({reviews.total})</h2>
         
-        <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-hidden">
-          <table className="w-full">
+        <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl overflow-x-auto">
+          <table className="w-full min-w-[800px]">
             <thead>
               <tr className="border-b border-[var(--border)] bg-[var(--bg-secondary)]">
                 <th className="text-left py-3 px-4 text-sm font-semibold text-[var(--text-secondary)]">Time</th>


### PR DESCRIPTION
<!-- oc-session:discord:1477780690081681622 -->

## Problem
Tables on mobile devices were clipped by `overflow-hidden` instead of being scrollable horizontally.

## Solution
- Changed `overflow-hidden` → `overflow-x-auto` on all table container divs
- Added `min-width` to tables to ensure they maintain proper layout when scrolling

## Affected pages
- `/admin/repos`
- `/admin/deployments`
- `/admin/events`
- `/admin/reviews`
- `/admin/repos/[owner]/[repo]` (all 3 tabs)