### PR TITLE
feat: OpenResponses API for browser-based E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,62 @@ Uses the Coolify Traefik proxy bridge:
 - Auth: Bearer token
 
 See COOLIFY_INSTANCES.md for bridge setup details.
-# Test 1772215693
-# Test 1772215887
-# Test 1772216099
+
+## Advanced: Browser-Based E2E Tests
+
+jean-ci can run natural language E2E tests using OpenClaw's browser capabilities.
+
+### Enable OpenResponses API
+
+Set the environment variable to use the full agent codepath:
+
+```bash
+OPENCLAW_USE_RESPONSES=true
+```
+
+This switches from `/v1/chat/completions` (LLM only) to `/v1/responses` (full agent with tools).
+
+**Requires:** The Gateway must have responses endpoint enabled:
+```json
+{
+  "gateway": {
+    "http": {
+      "endpoints": {
+        "responses": { "enabled": true }
+      }
+    }
+  }
+}
+```
+
+### Writing E2E Tests
+
+Create `.jean-ci/pr-checks/e2e-*.md` files with natural language test instructions:
+
+```markdown
+## Test: Login Flow
+
+1. Open https://your-app.com in the browser
+2. Click "Sign In"
+3. Enter test@example.com as email
+4. Submit the form
+5. Verify "Welcome back" appears on the dashboard
+
+VERDICT: PASS if all steps succeed, FAIL otherwise.
+```
+
+The agent will:
+- Use browser automation to execute each step
+- Take screenshots on failure
+- Report PASS/FAIL based on results
+
+### Preview Deployments
+
+For testing against PR preview deployments, use variables in your prompts:
+
+```markdown
+Open {{PREVIEW_URL}} in the browser...
+```
+
+(Preview URL injection coming soon)
 

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -3,6 +3,10 @@ import { SYSTEM_PROMPT } from './db';
 const OPENCLAW_GATEWAY_URL = process.env.OPENCLAW_GATEWAY_URL;
 const OPENCLAW_GATEWAY_TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN;
 
+// Use OpenResponses API for full agent capabilities (including browser tools)
+// Falls back to chat/completions if OPENCLAW_USE_RESPONSES is not set
+const USE_RESPONSES_API = process.env.OPENCLAW_USE_RESPONSES === 'true';
+
 export async function callOpenClaw(userPrompt: string, context = '') {
   if (!OPENCLAW_GATEWAY_URL || !OPENCLAW_GATEWAY_TOKEN) {
     console.log('[MOCK] Would call OpenClaw');
@@ -12,28 +16,101 @@ export async function callOpenClaw(userPrompt: string, context = '') {
   const userMessage = `${userPrompt}\n\n## Pull Request Details\n${context}`;
 
   try {
-    const response = await fetch(`${OPENCLAW_GATEWAY_URL}/v1/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${OPENCLAW_GATEWAY_TOKEN}`,
-      },
-      body: JSON.stringify({
-        model: 'default',
-        messages: [
-          { role: 'system', content: SYSTEM_PROMPT },
-          { role: 'user', content: userMessage },
-        ],
-      }),
-    });
-    
-    if (!response.ok) {
-      return { success: false, error: await response.text() };
+    if (USE_RESPONSES_API) {
+      return await callOpenClawResponses(userMessage);
+    } else {
+      return await callOpenClawChat(userMessage);
     }
-    
-    const data = await response.json();
-    return { success: true, response: data.choices?.[0]?.message?.content || 'No response' };
   } catch (error: any) {
     return { success: false, error: error.message };
   }
+}
+
+/**
+ * OpenResponses API (/v1/responses)
+ * Full agent codepath with tool access (browser, exec, etc.)
+ */
+async function callOpenClawResponses(userMessage: string) {
+  const response = await fetch(`${OPENCLAW_GATEWAY_URL}/v1/responses`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${OPENCLAW_GATEWAY_TOKEN}`,
+      'x-openclaw-agent-id': 'main',
+    },
+    body: JSON.stringify({
+      model: 'openclaw:main',
+      input: [
+        { type: 'message', role: 'developer', content: SYSTEM_PROMPT },
+        { type: 'message', role: 'user', content: userMessage },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    return { success: false, error: await response.text() };
+  }
+
+  const data = await response.json();
+  
+  // Extract text from output items
+  const textContent = extractTextFromOutput(data.output || []);
+  
+  if (!textContent) {
+    return { success: false, error: 'No text response from agent' };
+  }
+  
+  return { success: true, response: textContent };
+}
+
+/**
+ * Chat Completions API (/v1/chat/completions)
+ * Simple LLM call without tool access
+ */
+async function callOpenClawChat(userMessage: string) {
+  const response = await fetch(`${OPENCLAW_GATEWAY_URL}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${OPENCLAW_GATEWAY_TOKEN}`,
+    },
+    body: JSON.stringify({
+      model: 'default',
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: userMessage },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    return { success: false, error: await response.text() };
+  }
+
+  const data = await response.json();
+  return { success: true, response: data.choices?.[0]?.message?.content || 'No response' };
+}
+
+/**
+ * Extract text content from OpenResponses output items
+ */
+function extractTextFromOutput(output: any[]): string {
+  const textParts: string[] = [];
+  
+  for (const item of output) {
+    if (item.type === 'message' && item.content) {
+      // Content can be string or array of content parts
+      if (typeof item.content === 'string') {
+        textParts.push(item.content);
+      } else if (Array.isArray(item.content)) {
+        for (const part of item.content) {
+          if (part.type === 'output_text' || part.type === 'text') {
+            textParts.push(part.text || '');
+          }
+        }
+      }
+    }
+  }
+  
+  return textParts.join('\n').trim();
 }


### PR DESCRIPTION
<!-- oc-session:discord:1478242474693754891 -->

## Summary

Adds support for OpenClaw's OpenResponses API (`/v1/responses`) which provides full agent capabilities including browser automation.

## Changes

- **`lib/llm.ts`**: Add `OPENCLAW_USE_RESPONSES` env var to switch between:
  - `/v1/chat/completions` (default) — LLM-only, no tools
  - `/v1/responses` — Full agent with browser, exec, etc.

- **`README.md`**: Document browser-based E2E testing feature

## Why

This enables **natural language E2E tests** in `.jean-ci/pr-checks/`:

```markdown
## Test: Login Flow

1. Open https://your-app.com in the browser
2. Click "Sign In"  
3. Enter test@example.com as email
4. Verify "Welcome back" appears

VERDICT: PASS if all steps succeed
```

The agent executes these steps using browser automation and reports PASS/FAIL.

## Setup Required

1. Set `OPENCLAW_USE_RESPONSES=true` in jean-ci env vars
2. Enable responses endpoint in Gateway config:
   ```json
   { "gateway": { "http": { "endpoints": { "responses": { "enabled": true } } } } }
   ```

## Backwards Compatible

Default behavior unchanged — only activates when `OPENCLAW_USE_RESPONSES=true`.