### PR TITLE
fix: Deduplicate registry_package events

### DIFF
--- a/lib/smoke-tests.ts
+++ b/lib/smoke-tests.ts
@@ -80,7 +80,23 @@ export async function runSmokeTests(pending: PendingDeployment): Promise<void> {
   
   console.log(`🧪 Running smoke tests for ${owner}/${repo}@${headSha.slice(0, 7)}`);
   
-  const octokit = await getInstallationOctokit(installation_id);
+  if (!installation_id) {
+    console.error('Smoke tests: missing installation_id');
+    return;
+  }
+  
+  let octokit;
+  try {
+    octokit = await getInstallationOctokit(installation_id);
+  } catch (e: any) {
+    console.error(`Smoke tests: failed to get octokit for installation ${installation_id}: ${e.message}`);
+    return;
+  }
+  
+  if (!octokit) {
+    console.error(`Smoke tests: octokit is undefined for installation ${installation_id}`);
+    return;
+  }
   
   // Fetch smoke tests from repo
   const smokeTests = await fetchSmokeTests(octokit, owner, repo, headSha);

--- a/lib/webhook-handlers.ts
+++ b/lib/webhook-handlers.ts
@@ -97,6 +97,9 @@ export async function handleInstallation(payload: any) {
   }
 }
 
+// Track in-flight deployments to prevent duplicate processing
+const inFlightDeployments = new Set<string>();
+
 export async function handleRegistryPackage(payload: any) {
   const { action, registry_package, repository, sender } = payload;
   
@@ -109,6 +112,17 @@ export async function handleRegistryPackage(payload: any) {
   const packageVersion = registry_package?.package_version?.version;
   const packageUrl = registry_package?.package_version?.package_url || 
                      `ghcr.io/${repository.full_name.toLowerCase()}`;
+  const headSha = registry_package?.package_version?.target_oid;
+  
+  // Deduplicate: skip if already processing this package+SHA combination
+  const dedupeKey = `${packageUrl}:${headSha}`;
+  if (inFlightDeployments.has(dedupeKey)) {
+    console.log(`⏭️ Skipping duplicate registry_package for ${dedupeKey}`);
+    return;
+  }
+  inFlightDeployments.add(dedupeKey);
+  // Clean up after 5 minutes
+  setTimeout(() => inFlightDeployments.delete(dedupeKey), 5 * 60 * 1000);
   
   console.log(`📦 Package published: ${packageUrl}:${packageVersion}`);
 
@@ -122,7 +136,6 @@ export async function handleRegistryPackage(payload: any) {
   const [owner, repo] = repository.full_name.split('/');
   
   const ref = registry_package?.package_version?.target_commitish || repository.default_branch || 'main';
-  const headSha = registry_package?.package_version?.target_oid;
   
   const coolifyConfig = await fetchCoolifyConfig(octokit, owner, repo, ref);
   


### PR DESCRIPTION
## Problem

Duplicate `registry_package` webhooks cause:
1. Multiple GitHub Check runs created for same commit
2. Second event overwrites pending deployment with new check_run_id
3. Coolify webhook updates wrong check (first one's ID)
4. Second check stays stuck in 'in_progress' forever

## Solution

1. **In-memory deduplication**: Track `package+SHA` combinations, skip duplicates within 5 minutes
2. **Better smoke test error handling**: Catch octokit initialization failures gracefully

## Changes

- `webhook-handlers.ts`: Add `inFlightDeployments` Set to track active deployments
- `smoke-tests.ts`: Wrap octokit init in try/catch, add null checks