### PR TITLE
feat: different review handling for draft PRs

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -110,6 +110,17 @@ export async function initDatabase() {
         completed_at TIMESTAMP
       );
 
+      CREATE TABLE IF NOT EXISTS jean_ci_pr_reviews (
+        id SERIAL PRIMARY KEY,
+        pr_number INTEGER NOT NULL,
+        repo TEXT NOT NULL,
+        last_reviewed_sha TEXT,
+        is_draft BOOLEAN DEFAULT FALSE,
+        draft_reviewed BOOLEAN DEFAULT FALSE,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE (repo, pr_number)
+      );
+
       CREATE TABLE IF NOT EXISTS jean_ci_pending_deployments (
         id SERIAL PRIMARY KEY,
         app_uuid TEXT UNIQUE NOT NULL,
@@ -222,6 +233,15 @@ export interface CheckRun {
   completed_at?: Date;
 }
 
+export interface PRReviewState {
+  pr_number: number;
+  repo: string;
+  last_reviewed_sha?: string;
+  is_draft: boolean;
+  draft_reviewed: boolean;
+  updated_at: Date;
+}
+
 export async function insertCheckRun(data: {
   github_check_id?: number;
   repo: string;
@@ -268,6 +288,33 @@ export async function setCheckRunGithubId(id: number, githubCheckId: number) {
 export async function getCheckRun(id: number): Promise<CheckRun | null> {
   const result = await pool.query('SELECT * FROM jean_ci_check_runs WHERE id = $1', [id]);
   return result.rows[0] || null;
+}
+
+export async function getPRReviewState(repo: string, prNumber: number): Promise<PRReviewState | null> {
+  const result = await pool.query(
+    'SELECT * FROM jean_ci_pr_reviews WHERE repo = $1 AND pr_number = $2',
+    [repo, prNumber]
+  );
+  return result.rows[0] || null;
+}
+
+export async function upsertPRReviewState(data: {
+  pr_number: number;
+  repo: string;
+  last_reviewed_sha?: string;
+  is_draft: boolean;
+  draft_reviewed: boolean;
+}) {
+  await pool.query(`
+    INSERT INTO jean_ci_pr_reviews
+    (pr_number, repo, last_reviewed_sha, is_draft, draft_reviewed, updated_at)
+    VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
+    ON CONFLICT (repo, pr_number) DO UPDATE SET
+      last_reviewed_sha = $3,
+      is_draft = $4,
+      draft_reviewed = $5,
+      updated_at = CURRENT_TIMESTAMP
+  `, [data.pr_number, data.repo, data.last_reviewed_sha || null, data.is_draft, data.draft_reviewed]);
 }
 
 // Event helpers

--- a/lib/webhook-handlers.ts
+++ b/lib/webhook-handlers.ts
@@ -1,4 +1,4 @@
-import { upsertRepo, getRepo } from './db';
+import { upsertRepo, getRepo, insertEvent, getPRReviewState, upsertPRReviewState } from './db';
 import { runPRReview } from './pr-review';
 import { getInstallationOctokit, createGitHubDeployment, updateDeploymentStatus, createCheck, updateCheck } from './github';
 import { fetchCoolifyConfig, getCoolifyAppDetails, triggerCoolifyDeploy, registerPendingDeployment } from './coolify';
@@ -10,19 +10,125 @@ const OPENCLAW_NOTIFY_ON_CHANGES_REQUESTED = process.env.OPENCLAW_NOTIFY_ON_CHAN
 
 // Regex to extract session key from PR body: <!-- oc-session:key -->
 const SESSION_REGEX = /<!--\s*oc-session:([^\s]+)\s*-->/;
+const REVIEW_TRIGGER_REGEX = /(^|\s)\/review(\s|$)/i;
+const MENTION_TRIGGER = '@jean-ci review';
+
+function enqueuePRReview(installationId: number, owner: string, repo: string, prNumber: number, headSha: string) {
+  runPRReview(installationId, owner, repo, prNumber, headSha)
+    .catch(err => console.error('PR review error:', err));
+}
 
 export async function handlePullRequest(payload: any) {
   const { action, pull_request, repository, installation } = payload;
   const repo = repository.full_name;
-  
+
   await upsertRepo(repo, installation.id, false);
-  
-  if (action === 'opened' || action === 'synchronize' || action === 'reopened') {
-    const [owner, repoName] = repo.split('/');
-    // Run asynchronously
-    runPRReview(installation.id, owner, repoName, pull_request.number, pull_request.head.sha)
-      .catch(err => console.error('PR review error:', err));
+  const repoConfig = await getRepo(repo);
+  if (!repoConfig?.pr_review_enabled) {
+    return;
   }
+
+  const [owner, repoName] = repo.split('/');
+  const prNumber = pull_request.number;
+  const headSha = pull_request.head.sha;
+  const isDraft = !!pull_request.draft;
+
+  if (action === 'ready_for_review') {
+    const previousState = await getPRReviewState(repo, prNumber);
+    await upsertPRReviewState({
+      repo,
+      pr_number: prNumber,
+      last_reviewed_sha: headSha,
+      is_draft: false,
+      draft_reviewed: previousState?.draft_reviewed ?? false,
+    });
+    enqueuePRReview(installation.id, owner, repoName, prNumber, headSha);
+    return;
+  }
+
+  if (action !== 'opened' && action !== 'synchronize' && action !== 'reopened') {
+    return;
+  }
+
+  if (!isDraft) {
+    const previousState = await getPRReviewState(repo, prNumber);
+    await upsertPRReviewState({
+      repo,
+      pr_number: prNumber,
+      last_reviewed_sha: headSha,
+      is_draft: false,
+      draft_reviewed: previousState?.draft_reviewed ?? false,
+    });
+    enqueuePRReview(installation.id, owner, repoName, prNumber, headSha);
+    return;
+  }
+
+  const reviewState = await getPRReviewState(repo, prNumber);
+  if (reviewState?.draft_reviewed) {
+    await upsertPRReviewState({
+      repo,
+      pr_number: prNumber,
+      last_reviewed_sha: reviewState.last_reviewed_sha,
+      is_draft: true,
+      draft_reviewed: true,
+    });
+    console.log(`⏭️ Draft PR ${repo}#${prNumber} already reviewed once, skipping`);
+    return;
+  }
+
+  await upsertPRReviewState({
+    repo,
+    pr_number: prNumber,
+    last_reviewed_sha: headSha,
+    is_draft: true,
+    draft_reviewed: true,
+  });
+  enqueuePRReview(installation.id, owner, repoName, prNumber, headSha);
+}
+
+export async function handleIssueComment(payload: any) {
+  const { action, issue, comment, repository, installation } = payload;
+
+  if (action !== 'created' || !issue?.pull_request) {
+    return;
+  }
+
+  const body = (comment?.body || '').toLowerCase();
+  if (!REVIEW_TRIGGER_REGEX.test(body) && !body.includes(MENTION_TRIGGER)) {
+    return;
+  }
+
+  if (!installation?.id) {
+    console.log('issue_comment missing installation id, skipping review trigger');
+    return;
+  }
+
+  const repo = repository.full_name;
+  await upsertRepo(repo, installation.id, false);
+  const repoConfig = await getRepo(repo);
+  if (!repoConfig?.pr_review_enabled) {
+    return;
+  }
+
+  const [owner, repoName] = repo.split('/');
+  const prNumber = issue.number;
+
+  const octokit = await getInstallationOctokit(installation.id);
+  const { data: pr } = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+    owner,
+    repo: repoName,
+    pull_number: prNumber,
+  });
+
+  await upsertPRReviewState({
+    repo,
+    pr_number: prNumber,
+    last_reviewed_sha: pr.head.sha,
+    is_draft: !!pr.draft,
+    draft_reviewed: !!pr.draft,
+  });
+
+  enqueuePRReview(installation.id, owner, repoName, prNumber, pr.head.sha);
 }
 
 export async function handlePullRequestReview(payload: any) {
@@ -220,6 +326,26 @@ export async function handleRegistryPackage(payload: any) {
     logsUrl, appUrl,
     installationId: repoConfig.installation_id,
   });
+
+  // Record deployment started event (marks as pending in UI)
+  await insertEvent(
+    'coolify_deployment_started',
+    result.deploymentUuid || null,
+    repository.full_name,
+    'webhook_called',
+    {
+      app_uuid: deployment.coolify_app,
+      deployment_uuid: result.deploymentUuid,
+      _source_repo: repository.full_name,
+      _source_sha: headSha,
+      package_url: packageUrl,
+      package_version: packageVersion,
+      environment,
+      logs_url: logsUrl,
+      app_url: appUrl,
+    },
+    'jean-ci'
+  );
   
   console.log(`✅ Deploy triggered for ${repository.full_name}, waiting for Coolify webhook...`);
 }
@@ -231,6 +357,9 @@ export async function handleEvent(event: string, payload: any) {
       break;
     case 'pull_request_review':
       await handlePullRequestReview(payload);
+      break;
+    case 'issue_comment':
+      await handleIssueComment(payload);
       break;
     case 'installation':
     case 'installation_repositories':


### PR DESCRIPTION
## Summary
Implements #43 - smart review handling for draft PRs to reduce review spam.

## Behavior

| PR State | Trigger | Action |
|----------|---------|--------|
| Draft opened | `pull_request.opened` (draft=true) | Review once ✓ |
| Draft push | `pull_request.synchronize` (draft=true) | **Skip** (no review) |
| Comment `/review` | `issue_comment` | Review on demand |
| Ready for review | `pull_request.ready_for_review` | Review ✓ |
| Non-draft push | `pull_request.synchronize` (draft=false) | Review (unchanged) |

## Changes
- **Added `jean_ci_pr_reviews` table** to track draft review state
- **Updated `handlePullRequest`** to check draft status and skip already-reviewed drafts
- **Added `handleIssueComment`** for `/review` or `@jean-ci review` comment triggers
- Gated by `pr_review_enabled` config (respects per-repo settings)

## Testing
- ✅ Build passes (`npm run build`)
- Ready to test with a real draft PR

Closes #43