### PR TITLE
feat: add permanent Coolify app <-> GitHub repo mapping

### DIFF
--- a/app/api/webhook/coolify/route.ts
+++ b/app/api/webhook/coolify/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPendingDeployment, completePendingDeployment } from '@/lib/coolify';
 import { getInstallationOctokit, updateDeploymentStatus, updateCheck } from '@/lib/github';
-import { insertEvent } from '@/lib/db';
+import { insertEvent, getRepoForCoolifyApp } from '@/lib/db';
 import { runSmokeTests } from '@/lib/smoke-tests';
 
 export async function POST(req: NextRequest) {
@@ -13,7 +13,12 @@ export async function POST(req: NextRequest) {
   
   // Get pending deployment from database
   const pending = application_uuid ? await getPendingDeployment(application_uuid) : null;
-  const actualRepo = pending ? `${pending.owner}/${pending.repo}` : null;
+  
+  // Try to find repo from pending deployment, or fall back to permanent mapping
+  let actualRepo = pending ? `${pending.owner}/${pending.repo}` : null;
+  if (!actualRepo && application_uuid) {
+    actualRepo = await getRepoForCoolifyApp(application_uuid);
+  }
   const headSha = pending?.head_sha;
   
   // Store Coolify event in database with the actual repo that triggered the deploy

--- a/lib/coolify.ts
+++ b/lib/coolify.ts
@@ -93,6 +93,8 @@ import {
   savePendingDeployment as dbSavePendingDeployment, 
   getPendingDeployment as dbGetPendingDeployment,
   deletePendingDeployment as dbDeletePendingDeployment,
+  upsertCoolifyAppMapping,
+  updateCoolifyAppLastDeployment,
   PendingDeployment as DbPendingDeployment
 } from './db';
 
@@ -110,6 +112,7 @@ export interface PendingDeploymentInput {
 
 // Persist pending deployment to database
 export async function registerPendingDeployment(appUuid: string, deployment: PendingDeploymentInput) {
+  // Save temporary pending deployment tracking
   await dbSavePendingDeployment({
     app_uuid: appUuid,
     owner: deployment.owner,
@@ -122,7 +125,18 @@ export async function registerPendingDeployment(appUuid: string, deployment: Pen
     app_url: deployment.appUrl,
     installation_id: deployment.installationId,
   });
-  console.log(`[Coolify] Registered pending deployment for ${appUuid} (${deployment.owner}/${deployment.repo}@${deployment.headSha?.substring(0, 7) || 'unknown'}, deploy: ${deployment.coolifyDeploymentUuid || 'unknown'})`);
+
+  // Also persist permanent Coolify app <-> GitHub repo mapping
+  const githubRepo = `${deployment.owner}/${deployment.repo}`;
+  const appDetails = await getCoolifyAppDetails(appUuid);
+  await upsertCoolifyAppMapping(appUuid, githubRepo, {
+    coolifyInstance: 'carita', // TODO: detect from COOLIFY_URL
+    appName: appDetails?.name,
+    appFqdn: appDetails?.fqdn,
+  });
+  await updateCoolifyAppLastDeployment(appUuid);
+
+  console.log(`[Coolify] Registered pending deployment for ${appUuid} (${githubRepo}@${deployment.headSha?.substring(0, 7) || 'unknown'}, deploy: ${deployment.coolifyDeploymentUuid || 'unknown'})`);
 }
 
 // Get pending deployment from database

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -135,6 +135,21 @@ export async function initDatabase() {
         installation_id INTEGER NOT NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
+
+      -- Permanent mapping: Coolify app UUID ↔ GitHub repo
+      CREATE TABLE IF NOT EXISTS jean_ci_coolify_apps (
+        coolify_app_uuid TEXT PRIMARY KEY,
+        github_repo TEXT NOT NULL,
+        coolify_instance TEXT DEFAULT 'carita',
+        app_name TEXT,
+        app_fqdn TEXT,
+        last_deployment_at TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+      
+      -- Index for reverse lookup (repo -> apps)
+      CREATE INDEX IF NOT EXISTS idx_coolify_apps_github_repo ON jean_ci_coolify_apps(github_repo);
       
       -- Migration: add coolify_deployment_uuid if missing
       DO $$ BEGIN
@@ -979,6 +994,107 @@ export async function getAllPendingDeployments(): Promise<PendingDeployment[]> {
     'SELECT * FROM jean_ci_pending_deployments ORDER BY created_at DESC'
   );
   return result.rows;
+}
+
+// ============================================================
+// Coolify App Mapping (permanent repo <-> Coolify app tracking)
+// ============================================================
+
+export interface CoolifyAppMapping {
+  coolify_app_uuid: string;
+  github_repo: string;
+  coolify_instance: string;
+  app_name?: string;
+  app_fqdn?: string;
+  last_deployment_at?: Date;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/**
+ * Upsert a Coolify app mapping. Called when:
+ * 1. jean-ci triggers a deployment (we know repo + app UUID)
+ * 2. Manually via admin UI to backfill existing apps
+ */
+export async function upsertCoolifyAppMapping(
+  coolifyAppUuid: string,
+  githubRepo: string,
+  options?: {
+    coolifyInstance?: string;
+    appName?: string;
+    appFqdn?: string;
+  }
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO jean_ci_coolify_apps 
+       (coolify_app_uuid, github_repo, coolify_instance, app_name, app_fqdn, updated_at)
+     VALUES ($1, $2, $3, $4, $5, NOW())
+     ON CONFLICT (coolify_app_uuid) DO UPDATE SET
+       github_repo = EXCLUDED.github_repo,
+       coolify_instance = COALESCE(EXCLUDED.coolify_instance, jean_ci_coolify_apps.coolify_instance),
+       app_name = COALESCE(EXCLUDED.app_name, jean_ci_coolify_apps.app_name),
+       app_fqdn = COALESCE(EXCLUDED.app_fqdn, jean_ci_coolify_apps.app_fqdn),
+       updated_at = NOW()`,
+    [
+      coolifyAppUuid,
+      githubRepo,
+      options?.coolifyInstance || 'carita',
+      options?.appName || null,
+      options?.appFqdn || null,
+    ]
+  );
+}
+
+/**
+ * Mark the last deployment time for a Coolify app.
+ */
+export async function updateCoolifyAppLastDeployment(coolifyAppUuid: string): Promise<void> {
+  await pool.query(
+    `UPDATE jean_ci_coolify_apps 
+     SET last_deployment_at = NOW(), updated_at = NOW() 
+     WHERE coolify_app_uuid = $1`,
+    [coolifyAppUuid]
+  );
+}
+
+/**
+ * Get GitHub repo for a Coolify app UUID.
+ * Used when processing Coolify webhook events.
+ */
+export async function getRepoForCoolifyApp(coolifyAppUuid: string): Promise<string | null> {
+  const result = await pool.query(
+    'SELECT github_repo FROM jean_ci_coolify_apps WHERE coolify_app_uuid = $1',
+    [coolifyAppUuid]
+  );
+  return result.rows[0]?.github_repo || null;
+}
+
+/**
+ * Get all Coolify apps for a GitHub repo.
+ */
+export async function getCoolifyAppsForRepo(githubRepo: string): Promise<CoolifyAppMapping[]> {
+  const result = await pool.query(
+    'SELECT * FROM jean_ci_coolify_apps WHERE github_repo = $1 ORDER BY updated_at DESC',
+    [githubRepo]
+  );
+  return result.rows;
+}
+
+/**
+ * Get all Coolify app mappings.
+ */
+export async function getAllCoolifyAppMappings(): Promise<CoolifyAppMapping[]> {
+  const result = await pool.query(
+    'SELECT * FROM jean_ci_coolify_apps ORDER BY github_repo, coolify_instance'
+  );
+  return result.rows;
+}
+
+/**
+ * Delete a Coolify app mapping (when app is deleted from Coolify).
+ */
+export async function deleteCoolifyAppMapping(coolifyAppUuid: string): Promise<void> {
+  await pool.query('DELETE FROM jean_ci_coolify_apps WHERE coolify_app_uuid = $1', [coolifyAppUuid]);
 }
 
 export function buildCoolifyDeploymentUrl(appUuid: string, deploymentUuid: string, logsUrl?: string): string {


### PR DESCRIPTION
<!-- oc-session:discord:1479388394831483023 -->

## Problem

Coolify webhook events (task_success, task_failed, deployment events) include `application_uuid` but no `_source_repo`. This makes it hard to track which GitHub repo an event belongs to.

Currently, we only know the repo during active deployments (via `jean_ci_pending_deployments`), but that's temporary.

## Solution

Add a permanent mapping table `jean_ci_coolify_apps`:

```sql
CREATE TABLE jean_ci_coolify_apps (
  coolify_app_uuid TEXT PRIMARY KEY,
  github_repo TEXT NOT NULL,      -- e.g. 'telegraphic-dev/pikarama'
  coolify_instance TEXT,          -- e.g. 'carita'
  app_name TEXT,
  app_fqdn TEXT,
  last_deployment_at TIMESTAMP,
  created_at TIMESTAMP,
  updated_at TIMESTAMP
);
```

### When it's updated:
- **On deployment trigger**: `registerPendingDeployment()` now also calls `upsertCoolifyAppMapping()`
- **Future**: Admin UI to manually add/backfill existing apps

### When it's used:
- Coolify webhook handler looks up repo from this table when there's no pending deployment

## Changes

- `lib/db.ts`: New table + CRUD functions
- `lib/coolify.ts`: Call `upsertCoolifyAppMapping()` on deployment
- `app/api/webhook/coolify/route.ts`: Fallback to mapping lookup