### PR TITLE
feat: Coolify app → GitHub repo mapping for task events

### DIFF
--- a/app/api/webhook/coolify/route.ts
+++ b/app/api/webhook/coolify/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPendingDeployment, completePendingDeployment } from '@/lib/coolify';
 import { getInstallationOctokit, updateDeploymentStatus, updateCheck } from '@/lib/github';
-import { insertEvent } from '@/lib/db';
+import { insertEvent, getRepoForApp } from '@/lib/db';
 import { runSmokeTests } from '@/lib/smoke-tests';
 
 export async function POST(req: NextRequest) {
@@ -9,17 +9,25 @@ export async function POST(req: NextRequest) {
   
   console.log(`[Coolify] Event received:`, JSON.stringify(payload).substring(0, 500));
   
-  const { event, message, application_uuid, deployment_url, application_name, deployment_uuid } = payload;
+  const { event, message, application_uuid, deployment_url, application_name, deployment_uuid, task_uuid, task_name } = payload;
   
-  // Get pending deployment from database
+  // Get pending deployment from database (for deployment events)
   const pending = application_uuid ? await getPendingDeployment(application_uuid) : null;
-  const actualRepo = pending ? `${pending.owner}/${pending.repo}` : null;
+  
+  // Get repo from pending deployment OR from app mapping
+  let actualRepo = pending ? `${pending.owner}/${pending.repo}` : null;
+  if (!actualRepo && application_uuid) {
+    actualRepo = await getRepoForApp(application_uuid);
+  }
   const headSha = pending?.head_sha;
   
-  // Store Coolify event in database with the actual repo that triggered the deploy
+  // Use task_uuid or deployment_uuid as delivery_id
+  const deliveryId = task_uuid || deployment_uuid || null;
+  
+  // Store Coolify event in database with the actual repo
   await insertEvent(
     `coolify_${event || 'unknown'}`,
-    deployment_uuid || null,
+    deliveryId,
     actualRepo || application_name || null,
     event || null,
     {
@@ -27,6 +35,7 @@ export async function POST(req: NextRequest) {
       _source_repo: actualRepo,
       _source_sha: headSha,
       _app_name: application_name,
+      _task_name: task_name,
     },
     'coolify'
   );
@@ -35,9 +44,21 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ received: true, ignored: 'no app uuid' });
   }
   
+  // Handle task events (no pending deployment expected)
+  if (event === 'task_success' || event === 'task_failed') {
+    console.log(`[Coolify] Task event: ${task_name || 'unknown'} → ${event} (app: ${application_uuid}, repo: ${actualRepo || 'unmapped'})`);
+    return NextResponse.json({ 
+      received: true, 
+      event,
+      task_name,
+      repo: actualRepo,
+    });
+  }
+  
+  // For deployment events, we need a pending deployment
   if (!pending) {
-    console.log(`[Coolify] No pending deployment for ${application_uuid}`);
-    return NextResponse.json({ received: true, ignored: 'no pending deployment' });
+    console.log(`[Coolify] No pending deployment for ${application_uuid} (event: ${event})`);
+    return NextResponse.json({ received: true, event, ignored: 'no pending deployment' });
   }
   
   // Get Octokit for this installation

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -143,6 +143,23 @@ export async function initDatabase() {
           ALTER TABLE jean_ci_pending_deployments ADD COLUMN coolify_deployment_uuid TEXT;
         END IF;
       END $$;
+
+      -- Coolify app → GitHub repo mapping
+      -- Updated on each successful registry_package → Coolify deployment
+      CREATE TABLE IF NOT EXISTS jean_ci_app_mappings (
+        id SERIAL PRIMARY KEY,
+        coolify_app_uuid TEXT UNIQUE NOT NULL,
+        github_repo TEXT NOT NULL,
+        coolify_app_name TEXT,
+        coolify_app_fqdn TEXT,
+        installation_id INTEGER,
+        last_deployed_sha TEXT,
+        last_deployed_at TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_jean_ci_app_mappings_repo ON jean_ci_app_mappings(github_repo);
     `);
 
     // Migration: rename global_prompt -> user_prompt
@@ -1151,4 +1168,86 @@ export async function getPendingDeploymentsCount(): Promise<number> {
     'SELECT COUNT(*) as count FROM jean_ci_pending_deployments'
   );
   return parseInt(result.rows[0]?.count || '0', 10);
+}
+
+// =============================================================================
+// Coolify App Mappings
+// =============================================================================
+
+export interface AppMapping {
+  id: number;
+  coolify_app_uuid: string;
+  github_repo: string;
+  coolify_app_name: string | null;
+  coolify_app_fqdn: string | null;
+  installation_id: number | null;
+  last_deployed_sha: string | null;
+  last_deployed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export async function upsertAppMapping(data: {
+  coolify_app_uuid: string;
+  github_repo: string;
+  coolify_app_name?: string | null;
+  coolify_app_fqdn?: string | null;
+  installation_id?: number | null;
+  last_deployed_sha?: string | null;
+}): Promise<AppMapping> {
+  const result = await pool.query(
+    `INSERT INTO jean_ci_app_mappings 
+       (coolify_app_uuid, github_repo, coolify_app_name, coolify_app_fqdn, installation_id, last_deployed_sha, last_deployed_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+     ON CONFLICT (coolify_app_uuid) DO UPDATE SET
+       github_repo = $2,
+       coolify_app_name = COALESCE($3, jean_ci_app_mappings.coolify_app_name),
+       coolify_app_fqdn = COALESCE($4, jean_ci_app_mappings.coolify_app_fqdn),
+       installation_id = COALESCE($5, jean_ci_app_mappings.installation_id),
+       last_deployed_sha = COALESCE($6, jean_ci_app_mappings.last_deployed_sha),
+       last_deployed_at = CURRENT_TIMESTAMP,
+       updated_at = CURRENT_TIMESTAMP
+     RETURNING *`,
+    [
+      data.coolify_app_uuid,
+      data.github_repo,
+      data.coolify_app_name || null,
+      data.coolify_app_fqdn || null,
+      data.installation_id || null,
+      data.last_deployed_sha || null,
+    ]
+  );
+  return result.rows[0];
+}
+
+export async function getAppMappingByUuid(coolifyAppUuid: string): Promise<AppMapping | null> {
+  const result = await pool.query(
+    'SELECT * FROM jean_ci_app_mappings WHERE coolify_app_uuid = $1',
+    [coolifyAppUuid]
+  );
+  return result.rows[0] || null;
+}
+
+export async function getAppMappingsByRepo(githubRepo: string): Promise<AppMapping[]> {
+  const result = await pool.query(
+    'SELECT * FROM jean_ci_app_mappings WHERE github_repo = $1 ORDER BY updated_at DESC',
+    [githubRepo]
+  );
+  return result.rows;
+}
+
+export async function getAllAppMappings(): Promise<AppMapping[]> {
+  const result = await pool.query(
+    'SELECT * FROM jean_ci_app_mappings ORDER BY updated_at DESC'
+  );
+  return result.rows;
+}
+
+// Get repo name for a Coolify app UUID (for enriching events)
+export async function getRepoForApp(coolifyAppUuid: string): Promise<string | null> {
+  const result = await pool.query(
+    'SELECT github_repo FROM jean_ci_app_mappings WHERE coolify_app_uuid = $1',
+    [coolifyAppUuid]
+  );
+  return result.rows[0]?.github_repo || null;
 }

--- a/lib/webhook-handlers.ts
+++ b/lib/webhook-handlers.ts
@@ -1,4 +1,4 @@
-import { upsertRepo, getRepo, insertEvent, getPRReviewState, upsertPRReviewState } from './db';
+import { upsertRepo, getRepo, insertEvent, getPRReviewState, upsertPRReviewState, upsertAppMapping } from './db';
 import { runPRReview } from './pr-review';
 import { getInstallationOctokit, createGitHubDeployment, updateDeploymentStatus, createCheck, updateCheck } from './github';
 import { fetchCoolifyConfig, getCoolifyAppDetails, triggerCoolifyDeploy, registerPendingDeployment } from './coolify';
@@ -326,6 +326,17 @@ export async function handleRegistryPackage(payload: any) {
     logsUrl, appUrl,
     installationId: repoConfig.installation_id,
   });
+
+  // Store/update Coolify app → GitHub repo mapping
+  await upsertAppMapping({
+    coolify_app_uuid: deployment.coolify_app,
+    github_repo: repository.full_name,
+    coolify_app_name: appDetails?.name || null,
+    coolify_app_fqdn: appDetails?.fqdn || null,
+    installation_id: repoConfig.installation_id,
+    last_deployed_sha: headSha,
+  });
+  console.log(`📍 Mapped Coolify app ${deployment.coolify_app} → ${repository.full_name}`);
 
   // Record deployment started event (marks as pending in UI)
   await insertEvent(


### PR DESCRIPTION
<!-- oc-session:discord:1479389227744497664 -->

## Problem

Coolify sends webhook events (including scheduled task events) with `application_uuid` but no repo info. We need to map these to GitHub repos for proper tracking.

## Solution

Add a mapping table that tracks Coolify app UUIDs → GitHub repos. The mapping is populated during the existing `registry_package` → Coolify deployment flow, where we already have both pieces of information.

## Changes

### Database
- New table: `jean_ci_app_mappings`
  - `coolify_app_uuid` (unique) → `github_repo`
  - Also stores: `coolify_app_name`, `coolify_app_fqdn`, `installation_id`, `last_deployed_sha`

### Webhook Handler (`lib/webhook-handlers.ts`)
- Calls `upsertAppMapping()` after successful deployment trigger
- Logs the mapping: `📍 Mapped Coolify app X → owner/repo`

### Coolify Webhook (`app/api/webhook/coolify/route.ts`)
- Uses `getRepoForApp()` to look up repo when no pending deployment exists
- Properly handles `task_success` / `task_failed` events
- Enriches all events with `_source_repo`

## Result

Before:
```json
{"event": "task_success", "application_uuid": "abc123", "_source_repo": null}
```

After (once mapping exists):
```json
{"event": "task_success", "application_uuid": "abc123", "_source_repo": "telegraphic-dev/pikarama"}
```

## Migration

Schema auto-creates on startup. Existing apps will get mapped on next deployment.