### PR TITLE
fix: fallback to deployment_started SHA when pending deployment not found

### DIFF
--- a/app/api/webhook/coolify/route.ts
+++ b/app/api/webhook/coolify/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPendingDeployment, completePendingDeployment } from '@/lib/coolify';
 import { getInstallationOctokit, updateDeploymentStatus, updateCheck } from '@/lib/github';
-import { insertEvent, getRepoForApp, getLastDeploymentShaForApp, getPendingDeploymentByDeploymentUuid } from '@/lib/db';
+import { insertEvent, getRepoForApp, getLastDeploymentShaForApp, getPendingDeploymentByDeploymentUuid, getShaForDeploymentUuid } from '@/lib/db';
 import { runSmokeTests } from '@/lib/smoke-tests';
 
 export async function POST(req: NextRequest) {
@@ -24,9 +24,14 @@ export async function POST(req: NextRequest) {
     actualRepo = await getRepoForApp(application_uuid);
   }
   
-  // Get SHA from pending deployment, or fall back to most recent deployment_started event
+  // Get SHA from pending deployment, or look up from deployment_started event
   let headSha: string | undefined = pending?.head_sha;
+  if (!headSha && deployment_uuid) {
+    // Match by deployment_uuid - most reliable (handles duplicate deploys)
+    headSha = (await getShaForDeploymentUuid(deployment_uuid)) ?? undefined;
+  }
   if (!headSha && application_uuid) {
+    // Fall back to most recent deployment for this app
     headSha = (await getLastDeploymentShaForApp(application_uuid)) ?? undefined;
   }
   

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1276,6 +1276,20 @@ export async function getLastDeploymentShaForApp(coolifyAppUuid: string): Promis
   return result.rows[0]?.sha || null;
 }
 
+// Get SHA from coolify_deployment_started event by deployment_uuid
+// This is the most reliable way to match a deployment_success to its source commit
+export async function getShaForDeploymentUuid(deploymentUuid: string): Promise<string | null> {
+  const result = await pool.query(
+    `SELECT payload->>'_source_sha' as sha
+     FROM jean_ci_webhook_events 
+     WHERE event_type = 'coolify_deployment_started'
+       AND payload->>'deployment_uuid' = $1
+     LIMIT 1`,
+    [deploymentUuid]
+  );
+  return result.rows[0]?.sha || null;
+}
+
 // =============================================================================
 // Coolify Task Events (Cron Jobs)
 // =============================================================================


### PR DESCRIPTION
## Problem
When Coolify sends `deployment_success` webhook, the pending deployment may not exist because:
1. It was already cleaned up after a previous deploy completed
2. A newer deploy for the same app overwrote it (pending deployments are keyed by app_uuid)

This causes `_source_sha` to be null in `coolify_deployment_success` events, which breaks the pipeline view (can't match deploys to commits).

## Solution
Add a fallback that looks up the SHA from the most recent `coolify_deployment_started` event for that app when no pending deployment is found.

## Evidence
```sql
-- Started events have SHA, success events don't
SELECT event_type, payload->>'_source_sha' as sha
FROM jean_ci_webhook_events 
WHERE event_type LIKE 'coolify_deployment_%'
ORDER BY created_at DESC LIMIT 5;

-- Result: started has SHA, success has NULL
```

<!-- oc-session:discord:1479489072287322319 -->