### PR TITLE
fix: use unique delivery_id for task events

### DIFF
--- a/app/api/webhook/coolify/route.ts
+++ b/app/api/webhook/coolify/route.ts
@@ -35,8 +35,9 @@ export async function POST(req: NextRequest) {
     headSha = (await getLastDeploymentShaForApp(application_uuid)) ?? undefined;
   }
   
-  // Use task_uuid or deployment_uuid as delivery_id
-  const deliveryId = task_uuid || deployment_uuid || null;
+  // Use deployment_uuid or task_uuid+timestamp as delivery_id
+  // Task events reuse the same task_uuid, so we need timestamp for uniqueness
+  const deliveryId = deployment_uuid || (task_uuid ? `${task_uuid}-${Date.now()}` : null);
   
   // Store Coolify event in database with the actual repo
   await insertEvent(


### PR DESCRIPTION
## Problem
Task webhooks from Coolify reuse the same `task_uuid` for every execution of a scheduled task.

Combined with the unique constraint on `delivery_id`, this caused all but the first task event to be silently dropped due to duplicate key errors.

## Fix
Append timestamp to `task_uuid` for task events:
```typescript
const deliveryId = deployment_uuid || (task_uuid ? `${task_uuid}-${Date.now()}` : null);
```

## Evidence
```sql
-- Same task_uuid used for all executions
SELECT delivery_id FROM jean_ci_webhook_events WHERE event_type LIKE 'coolify_task%';
-- Only 1 row despite many task executions

-- Unique constraint causing silent failures
\d jean_ci_webhook_events
-- "jean_ci_webhook_events_delivery_id_key" UNIQUE CONSTRAINT
```

<!-- oc-session:discord:1479489072287322319 -->