### PR TITLE
fix: log insert errors instead of silent failure

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -351,8 +351,13 @@ export async function insertEvent(eventType: string, deliveryId: string | null, 
       INSERT INTO jean_ci_webhook_events (event_type, delivery_id, repo, action, payload, source)
       VALUES ($1, $2, $3, $4, $5, $6)
     `, [eventType, deliveryId, repo, action, JSON.stringify(payload), source]);
-  } catch (e) {
-    // Duplicate delivery - ignore
+  } catch (e: any) {
+    // 23505 = unique_violation (duplicate delivery_id)
+    if (e?.code === '23505') {
+      console.log(`[Event] Duplicate delivery ignored: ${eventType} ${deliveryId}`);
+    } else {
+      console.error(`[Event] Failed to insert ${eventType}:`, e?.message || e);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
`insertEvent` silently ignored all errors with a catch block that only said `// Duplicate delivery - ignore`.

This masked real issues like the task event `delivery_id` collision bug.

## Fix
Check for PostgreSQL error code `23505` (unique_violation) to distinguish between:
- **Expected duplicates**: Log at info level
- **Unexpected errors**: Log at error level

https://github.com/telegraphic-dev/jean-ci/blob/main/lib/db.ts#L354-L361

<!-- oc-session:discord:1479489072287322319 -->